### PR TITLE
Catch "Profile not found"

### DIFF
--- a/crates/coordinator/src/lib.rs
+++ b/crates/coordinator/src/lib.rs
@@ -170,7 +170,13 @@ fn get_latest(action_hash: ActionHash) -> ExternResult<Record> {
             "Malformed details".into()
         ))),
         Details::Record(element_details) => match element_details.updates.last() {
-            Some(update) => get_latest(update.action_address().clone()),
+            Some(update) => match get_latest(update.action_address().clone()) {
+                Ok(record) => Ok(record),
+                Err(_) => {
+                    println!("Failed to find latest record for Profile. Returning previous one.");
+                    Ok(element_details.record)
+                }
+            },
             None => Ok(element_details.record),
         },
     }


### PR DESCRIPTION
This PR catches a case where an update to a profile is visible in get_details of the previous action but the record of the update itself is not yet retrievable via get_details because it has not yet been gossiped. At least this is my interpretation of frequent occurrences of the "Profile not found" error in practice.